### PR TITLE
Add --drop to container-env to drop undesired variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,9 @@ into the `env` function
 - `docker` renders the environment variables as `-e` flags to the `docker` command
 
 Running the command as `eval "$(ecsq container-env <my_cluster> <my_service>) --format=export"` will
-automatically populate your environment with container's ECS environment variables.
+automatically populate your environment with container's ECS environment variables. If you want to omit
+specific variables here, you can provide a comma-separated list of names via the `--drop` flag. This list is
+case-insensitive, e.g. `--drop node_env,port` is the same as `--drop NODE_ENV,PORT`.
 
 ```
 > ecsq container-env ecs-prod applepicker --container applepicker

--- a/main.go
+++ b/main.go
@@ -353,6 +353,7 @@ Use the "task" command to get details of a task. For example:
 	var (
 		flagContainerName string
 		flagFormat        string
+		flagFilter        string
 	)
 	containerEnvCommand := app.Command("container-env", "List environment variables for the task's container. Use --format to choose the output format")
 	containerEnvCommand.Arg("cluster", "Name of the cluster").Required().StringVar(&argClusterName)
@@ -360,6 +361,7 @@ Use the "task" command to get details of a task. For example:
 	containerEnvCommand.Flag("container", "Name of the container").StringVar(&flagContainerName)
 	containerEnvCommand.Flag("format", "Format to render the environment variable in. The options are: export, shell, docker, table. Defaults to table").
 		Default("table").EnumVar(&flagFormat, "export", "shell", "docker", "table")
+	containerEnvCommand.Flag("filter", "Case-insensitive comma-separated list of variable names to drop").StringVar(&flagFilter)
 	containerEnvCommand.Action(func(ctx *kingpin.ParseContext) error {
 		task, err := getServiceDetail(svc, argClusterName, argServiceName)
 		app.FatalIfError(err, "Could not describe service")
@@ -388,6 +390,23 @@ Use the "task" command to get details of a task. For example:
 			app.Fatalf("Container not found")
 		}
 		KeyValuePairSlice(containerDefinition.Environment).Sort()
+
+		if flagFilter != "" {
+			filters := map[string]bool{}
+			for _, filter := range strings.Split(flagFilter, ",") {
+				filters[strings.ToLower(strings.TrimSpace(filter))] = true
+			}
+
+			filtered := []*ecs.KeyValuePair{}
+			for _, pair := range containerDefinition.Environment {
+				if _, ok := filters[strings.ToLower(*pair.Name)]; !ok {
+					filtered = append(filtered, pair)
+				}
+			}
+
+			containerDefinition.Environment = filtered
+		}
+
 		if flagFormat == "table" {
 			table := tablewriter.NewWriter(os.Stdout)
 			table.SetHeader([]string{"Name", "Value"})

--- a/main.go
+++ b/main.go
@@ -353,7 +353,7 @@ Use the "task" command to get details of a task. For example:
 	var (
 		flagContainerName string
 		flagFormat        string
-		flagFilter        string
+		flagDrop          string
 	)
 	containerEnvCommand := app.Command("container-env", "List environment variables for the task's container. Use --format to choose the output format")
 	containerEnvCommand.Arg("cluster", "Name of the cluster").Required().StringVar(&argClusterName)
@@ -361,7 +361,7 @@ Use the "task" command to get details of a task. For example:
 	containerEnvCommand.Flag("container", "Name of the container").StringVar(&flagContainerName)
 	containerEnvCommand.Flag("format", "Format to render the environment variable in. The options are: export, shell, docker, table. Defaults to table").
 		Default("table").EnumVar(&flagFormat, "export", "shell", "docker", "table")
-	containerEnvCommand.Flag("filter", "Case-insensitive comma-separated list of variable names to drop").StringVar(&flagFilter)
+	containerEnvCommand.Flag("drop", "Case-insensitive comma-separated list of variable names to drop").StringVar(&flagDrop)
 	containerEnvCommand.Action(func(ctx *kingpin.ParseContext) error {
 		task, err := getServiceDetail(svc, argClusterName, argServiceName)
 		app.FatalIfError(err, "Could not describe service")
@@ -391,9 +391,9 @@ Use the "task" command to get details of a task. For example:
 		}
 		KeyValuePairSlice(containerDefinition.Environment).Sort()
 
-		if flagFilter != "" {
+		if flagDrop != "" {
 			filters := map[string]bool{}
-			for _, filter := range strings.Split(flagFilter, ",") {
+			for _, filter := range strings.Split(flagDrop, ",") {
 				filters[strings.ToLower(strings.TrimSpace(filter))] = true
 			}
 


### PR DESCRIPTION
I thought it'd be nice to have an easy way to drop vars (e.g. sentry dsn to avoid reporting exceptions in a local environment) regardless of format (docker vs. export, etc).

```
$ ecsq container-env ecs-staging hello-world
-ePORT="4000" -eLOG_LEVEL="info" -eDATABASE_PORT="3306"
$ ecsq container-env ecs-staging hello-world --drop log_level,database_port
-ePORT="4000"
```