### PR TITLE
Extend regex to match new task UUID format.

### DIFF
--- a/main.go
+++ b/main.go
@@ -486,7 +486,7 @@ func ParseARN(s string) *ARN {
 	return arn
 }
 
-const reUUID = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+const reUUID = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]{32}"
 
 func isTaskARN(s string) bool {
 	return regexp.MustCompile(`arn:aws:ecs:[a-z]+-[a-z]+-\d:\d+:task/` + reUUID).MatchString(s)


### PR DESCRIPTION
Amazon introduced [new ARN formats for ECS resources](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids) some time ago.

The `ecsq task ...` command will not work for those of us who opted in to the new ARN format, and it will "think" it refers to a service:

```
brianc@localhost:/ $ ecsq task dev arn:aws:ecs:us-east-1:1111111111:task/dev/0b4b2b4daf475ee0bf19157238902649
Invalid task ID, assuming this is a service name. Looking up arbitrary task for service
Error listing tasks InvalidParameterException: Service Identifier is invalid
```

Extend regex to match the new task UUID format too.