### PR TITLE
update kingpin dependency

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,9 +16,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 
+	kingpin "github.com/alecthomas/kingpin/v2"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/olekukonko/tablewriter"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
 func main() {
@@ -487,9 +487,10 @@ func ParseARN(s string) *ARN {
 }
 
 const taskIDRawPattern = `(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]{32})`
+
 var (
-	taskIDPattern = regexp.MustCompile("^"+taskIDRawPattern+"$")
-	taskARNPattern = regexp.MustCompile(`^arn:aws:ecs:[a-z]+-[a-z]+-\d:\d+:task/(([a-zA-Z-])+/)?` + taskIDRawPattern+ "$")
+	taskIDPattern  = regexp.MustCompile("^" + taskIDRawPattern + "$")
+	taskARNPattern = regexp.MustCompile(`^arn:aws:ecs:[a-z]+-[a-z]+-\d:\d+:task/(([a-zA-Z-])+/)?` + taskIDRawPattern + "$")
 )
 
 func isTaskARN(s string) bool {


### PR DESCRIPTION
when attempting to run `go install github.com/mightyguava/ecsq@latest` we now get the following error:

```
go: github.com/mightyguava/ecsq imports
	gopkg.in/alecthomas/kingpin.v2: gopkg.in/alecthomas/kingpin.v2@v2.3.2: parsing go.mod:
	module declares its path as: github.com/alecthomas/kingpin/v2
	        but was required as: gopkg.in/alecthomas/kingpin.v2
```

This is due to the kingpin package having changed its path from gopkg to github. PR updates the requirement to the new correct location.